### PR TITLE
Kind request to deprecate package in favor of the official version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-meteor-hammer
-============
-A smart-package for bundling Hammer.js into your Meteor.js application for multi-touch gestures.
+This package is now deprecated in favor of the official integration -
 
-Package version will match Hammer.js version.
-
-##Installation
-
-In your Meteor.js project directory, run
-
-    $ meteor add chriswessels:hammer
-
-##License
-
-Please see the `LICENSE` file for more information.
+https://atmospherejs.com/hammer/hammer


### PR DESCRIPTION
Hi Chris,

I'm a fellow Meteor dev and [volunteer package curator on Atmosphere](https://github.com/percolatestudio/atmosphere-beta/issues/297). I found your Hammer.js wrapper and used it as inspiration for an [official Hammer <-> Meteor integration](https://github.com/hammerjs/hammer.js/pull/724).

Hammer.js now has an official package published at https://atmospherejs.com/hammer/hammer, with integration straight from the source repo, so the package will always be up to date.

Would you like to support this official version? If so, you can run

    meteor admin set-unmigrated chriswessels:hammer

Packages and apps that depend on your wrapper will still run fine; the package will only be hidden from Atmosphere searches.

Thanks!

Dan