### PR TITLE
Handle gesture event for each selector matching criteria

### DIFF
--- a/template_integration.js
+++ b/template_integration.js
@@ -43,12 +43,13 @@ function extractAction (actionString) {
 }
 function handleGestureEvent (gestureName, event) {
   _.each(Object.keys(gestureHandlers[gestureName]), function (selector, index) {
-    var eventElem = $(event.target).get(0),
-        selectorElem = $(selector).get(0);
+    _.each($(selector), function(selectorElem, index) {
+      var eventElem = $(event.target).get(0);
 
-    if (selectorElem && ($(eventElem).is(selector) || $.contains(selectorElem, eventElem))) {
-      gestureHandlers[gestureName][selector].call(Blaze.getData(eventElem), event);
-    }
+      if (selectorElem && ($(eventElem).is(selector) || $.contains(selectorElem, eventElem))) {
+          gestureHandlers[gestureName][selector].call(Blaze.getData(eventElem), event);
+      }
+    });
   });
   return true;
 }


### PR DESCRIPTION
Hi @chriswessels!

I have found one more issue in current version. E.g I have press gesture 'press button.something' and it can match multiple elements (in this example span is same size as whole button):

```
<button class="something"><span class="red"></span></button>
<button class="something"><span class="yellow"></span></button>
<button class="something"><span class="green"></span></button>
```

So gesture selector will be here array with three buttons. But when I press on span.yellow, the event element will be  ```<span class="yellow"></span>```. handleGestureEvent function will check now if event element is contained in first selector only and it will not trigger gesture for second button which matches the criteria. I have changed this implementation to check if element is contained in each matched selector.

